### PR TITLE
Rename project to terratools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,14 @@ guide on the process of contributing to an open-source project
 ## Bug reports
 It is a great help to the community if you report any bugs that you
 may find. We keep track of all open issues related to TerraTools
-[here](https://github.com/mantle-convection-constrained/terra_tools/issues). 
+[here](https://github.com/mantle-convection-constrained/terratools/issues). 
 
 Please follow these simple instructions before opening a new bug report:
 
 - Do a quick search in the list of open and closed issues for a duplicate of
   your issue.
 - If you did not find an answer, open a new
-  [issue](https://github.com/mantle-convection-constrained/terra_tools/issues/new) and explain your
+  [issue](https://github.com/mantle-convection-constrained/terratools/issues/new) and explain your
   problem in as much detail as possible.
 - Attach as much as possible of the following information to your issue:
   - a minimal set of instructions that reproduce the issue,

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 Tools to read, analyse and visualise models written by the TERRA mantle convection code.
 TerraTools is released under an MIT License.
 
-Homepage: [https://terra-tools.readthedocs.io/en/latest/](https://terra-tools.readthedocs.io/en/latest/)<br>
-Documentation: [https://terra-tools.readthedocs.io/en/latest/](https://terra-tools.readthedocs.io/en/latest/)<br>
-Source code: [https://github.com/mantle-convection-constrained/terra_tools](https://github.com/mantle-convection-constrained/terra_tools)
+Homepage: [https://terratools.readthedocs.io/en/latest/](https://terratools.readthedocs.io/en/latest/)<br>
+Documentation: [https://terratools.readthedocs.io/en/latest/](https://terratools.readthedocs.io/en/latest/)<br>
+Source code: [https://github.com/mantle-convection-constrained/terratools](https://github.com/mantle-convection-constrained/terratools)
 
 ## Citing TerraTools
 We are currently writing a paper for submission to JOSS. Watch this space.
 
 ## Reporting bugs
-If you would like to report any bugs, please raise an issue on [GitHub](https://github.com/mantle-convection-constrained/terra_tools/issues).
+If you would like to report any bugs, please raise an issue on [GitHub](https://github.com/mantle-convection-constrained/terratools/issues).
 
 ## Contributing to TerraTools
-If you would like to contribute bug fixes, new functions or new modules to the existing codebase, please fork the terra_tools repository, make the desired changes and then make a pull request on [GitHub](https://github.com/mantle-convection-constrained/terra_tools/pulls).
+If you would like to contribute bug fixes, new functions or new modules to the existing codebase, please fork the terratools repository, make the desired changes and then make a pull request on [GitHub](https://github.com/mantle-convection-constrained/terratools/pulls).
 
 ## Acknowledgement and Support
 This project is supported by [NERC Large Grant MC-squared](https://www.cardiff.ac.uk/research/explore/find-a-project/view/2592859-mc2-mantle-circulation-constrained).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,18 +2,18 @@
 Tools to read, analyse and visualise models written by the TERRA mantle convection code.
 TerraTools is released under an MIT License.
 
-Homepage: [https://terra-tools.readthedocs.io/en/latest/](https://terra-tools.readthedocs.io/en/latest/)<br>
-Documentation: [https://terra-tools.readthedocs.io/en/latest/](https://terra-tools.readthedocs.io/en/latest/)<br>
-Source code: [https://github.com/mantle-convection-constrained/terra_tools](https://github.com/mantle-convection-constrained/terra_tools)
+Homepage: [https://terratools.readthedocs.io/en/latest/](https://terratools.readthedocs.io/en/latest/)<br>
+Documentation: [https://terratools.readthedocs.io/en/latest/](https://terratools.readthedocs.io/en/latest/)<br>
+Source code: [https://github.com/mantle-convection-constrained/terratools](https://github.com/mantle-convection-constrained/terratools)
 
 ## Citing TerraTools
 We are currently writing a paper for submission to JOSS. Watch this space.
 
 ## Reporting bugs
-If you would like to report any bugs, please raise an issue on [GitHub](https://github.com/mantle-convection-constrained/terra_tools/issues).
+If you would like to report any bugs, please raise an issue on [GitHub](https://github.com/mantle-convection-constrained/terratools/issues).
 
 ## Contributing to TerraTools
-If you would like to contribute bug fixes, new functions or new modules to the existing codebase, please fork the terra_tools repository, make the desired changes and then make a pull request on [GitHub](https://github.com/mantle-convection-constrained/terra_tools/pulls).
+If you would like to contribute bug fixes, new functions or new modules to the existing codebase, please fork the terratools repository, make the desired changes and then make a pull request on [GitHub](https://github.com/mantle-convection-constrained/terratools/pulls).
 
 ## Acknowledgement and Support
 This project is supported by [NERC Large Grant MC-squared](https://www.cardiff.ac.uk/research/explore/find-a-project/view/2592859-mc2-mantle-circulation-constrained).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,6 @@ classifiers = [
 dependencies = [ "numpy" ]
 
 [project.urls]
-"Homepage" = "https://github.com/mantle-convection-constrained/terra_tools"
-"Bug Tracker" = "https://github.com/mantle-convection-constrained/terra_tools/issues"
-"Documentation" = "https://readthedocs.org/projects/terra-tools"
+"Homepage" = "https://github.com/mantle-convection-constrained/terratools"
+"Bug Tracker" = "https://github.com/mantle-convection-constrained/terratools/issues"
+"Documentation" = "https://readthedocs.org/projects/terratools"


### PR DESCRIPTION
The module name `terra_tools` would be transformed to `terra-tools`
by PyPI, so mush the words together and call it `terratools`.

This commit changes all the names but does not change any website
addresses externally.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. 

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

