### PR TITLE
Add nearest-neighbour lookup for `TerraModel`s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,10 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 numpy = "^1.23"
-scipy = "^1.7"
+scipy = "^1.6"
 netcdf4 = "^1"
 matplotlib = "^3.5"
+scikit-learn = "^1.1.2"
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.5.0"

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -87,7 +87,8 @@ class NoFieldError(Exception):
 
 class FieldDimensionError(Exception):
     """
-    Exception type raised when trying to access a field which is not present
+    Exception type raised when trying to set a field when the dimensions
+    do not match the coordinates in the model
     """
     def __init__(self, model, array, name=""):
         self.message = f"Field array {name} has incorrect first two dimensions. " + \
@@ -144,6 +145,14 @@ class TerraModel:
     ``lon, lat = m.get_lateral_points()`` and the radii ``r = m.get_radii()``,
     the temperature at ``lon[ip], lat[ip]`` and radius ``r[ir]`` is given
     by ``temp[ir,ip]``.
+
+    Nearest neighbours
+    ------------------
+    The nearest lateral point index to an arbitrary geographic location
+    can be obtained by ``m.nearest_index(lon, lat)``, whilst the nearest
+    ``n`` neighbours can be obtained with ``m.nearest_indices(lon, lat, n)``.
+    ``m.nearest_neighbours(lon, lat, n)`` also returns the distances to
+    each near-neighbour.
     """
 
     def __init__(self, lon, lat, r,

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -433,11 +433,12 @@ class TerraModel:
         """
         return self._radius
 
+
     def nearest_index(self, lon, lat):
         """
         Return the index or indices of the lateral point(s) nearest to the
         one or more points supplied.  lon and lat may either both be a scalar or
-        both an array of points; behvaiour is undefined if the a mix is
+        both an array of points; behaviour is undefined if a mix is
         provided.
 
         :param lon: Longitude of point(s) of interest (degrees)
@@ -445,6 +446,34 @@ class TerraModel:
         :returns: the index or indices of the nearest lateral point.
             This is a scalar for scalar input, and an array for array input.
         """
+        scalar_input = False
+        if np.isscalar(lon) and np.isscalar(lat):
+            scalar_input = True
+
+        indices = self.nearest_indices(lon, lat, 1)
+        if scalar_input:
+            return indices[0]
+        else:
+            return np.array([idx[0] for idx in indices])
+
+
+    def nearest_indices(self, lon, lat, n):
+        """
+        Return the indices of the lateral point(s) nearest to the
+        one or more points supplied.  lon and lat may either both be a scalar or
+        both an array of points; behaviour is undefined if a mix is
+        provided.
+
+        :param lon: Longitude of point(s) of interest (degrees)
+        :param lat: Latitude of point(s) of interest (degrees)
+        :param n: Number of nearest neighbours to find
+        :returns: the indices of the nearest n lateral points.
+            This is vector for scalar input, and a vector of vectors for array
+            input.
+        """
+        if n < 1:
+            raise ValueError("n must be 1 or more")
+
         scalar_input = False
 
         if np.isscalar(lon) and np.isscalar(lat):
@@ -457,13 +486,13 @@ class TerraModel:
         lon_radians = np.radians(lon)
         lat_radians = np.radians(lat)
         coords = np.array([[lat, lon] for lon, lat in zip(lon_radians, lat_radians)])
-        indices = self._knn_tree.kneighbors(coords, n_neighbors=1,
+        indices = self._knn_tree.kneighbors(coords, n_neighbors=n,
             return_distance=False)
 
         if scalar_input:
-            return indices[0][0]
+            return indices[0]
         else:
-            return np.array([idx[0] for idx in indices])
+            return indices
 
 
 def read_netcdf(files, fields=None, surface_radius=6370.0, test_lateral_points=False):

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -261,6 +261,7 @@ class TestTerraModelNewField(unittest.TestCase):
         self.assertTrue(
             fields_are_equal(model.get_field("c_hist"), np.zeros((nlayers, npts, 2))))
 
+
 class TestTerraModelRepr(unittest.TestCase):
     def test_repr(self):
         npts = 3
@@ -281,6 +282,15 @@ class TestTerraModelRepr(unittest.TestCase):
   number of lateral points: 3
                     fields: ['t', 'c_hist']
          composition names: ['a', 'b']""")
+
+
+class TestTerraModelNearestIndex(unittest.TestCase):
+    def test_nearest_index(self):
+        lon = [20, 22, 0.1, 25]
+        lat = [20, 22, 0.1, 24]
+        r = [10, 20]
+        model = TerraModel(lon, lat, r)
+        self.assertEqual(model.nearest_index(0, 0), 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -293,6 +293,8 @@ class TestTerraModelNearestIndex(unittest.TestCase):
         self.assertEqual(model.nearest_index(0, 0), 2)
         self.assertCountEqual(model.nearest_index([0, 0.1], [0, 0.1]), [2, 2], 2)
 
+
+class TestTerraModelNearestIndices(unittest.TestCase):
     def test_nearest_indices_zero_n(self):
         with self.assertRaises(ValueError):
             dummy_model().nearest_indices(0, 0, 0)
@@ -303,9 +305,33 @@ class TestTerraModelNearestIndex(unittest.TestCase):
         r = [10, 20]
         model = TerraModel(lon, lat, r)
         self.assertCountEqual(model.nearest_indices(0, 0, n=3), [2, 0, 1])
+
         indices = model.nearest_indices([0, 0.1], [0, 0.1], n=4)
         for inds in indices:
             self.assertCountEqual(inds, [2, 0, 1, 3], 4)
+
+
+class TestTerraModelNearestNeighbors(unittest.TestCase):
+    def test_nearest_neighbors_zero_n(self):
+        with self.assertRaises(ValueError):
+            dummy_model().nearest_neighbors(0, 0, 0)
+
+    def test_nearest_neighbors(self):
+        lon = [0, 0, 0, 0]
+        lat_radians = [0, 0.1, -0.2, 0.3]
+        lat = np.degrees(lat_radians)
+        r = [1]
+        model = TerraModel(lon, lat, r)
+        indices, distances = model.nearest_neighbors(0, 0, 4)
+        self.assertTrue(np.allclose(distances, [0, 0.1, 0.2, 0.3], atol=1e-7))
+        self.assertTrue(np.allclose(indices, [0, 1, 2, 3], atol=1e-7))
+
+        indices, distances = model.nearest_neighbors([0, 0],
+            [0, np.degrees(0.1)], n=4)
+        self.assertTrue(np.allclose(distances[0], [0, 0.1, 0.2, 0.3]))
+        self.assertTrue(np.allclose(indices[0], [0, 1, 2, 3]))
+        self.assertTrue(np.allclose(distances[1], [0.0, 0.1, 0.2, 0.3]))
+        self.assertTrue(np.allclose(indices[1], [1, 0, 3, 2]))
 
 
 if __name__ == '__main__':

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -291,6 +291,21 @@ class TestTerraModelNearestIndex(unittest.TestCase):
         r = [10, 20]
         model = TerraModel(lon, lat, r)
         self.assertEqual(model.nearest_index(0, 0), 2)
+        self.assertCountEqual(model.nearest_index([0, 0.1], [0, 0.1]), [2, 2], 2)
+
+    def test_nearest_indices_zero_n(self):
+        with self.assertRaises(ValueError):
+            dummy_model().nearest_indices(0, 0, 0)
+
+    def test_nearest_indices(self):
+        lon = [20, 22, 0.1, 25]
+        lat = [20, 22, 0.1, 24]
+        r = [10, 20]
+        model = TerraModel(lon, lat, r)
+        self.assertCountEqual(model.nearest_indices(0, 0, n=3), [2, 0, 1])
+        indices = model.nearest_indices([0, 0.1], [0, 0.1], n=4)
+        for inds in indices:
+            self.assertCountEqual(inds, [2, 0, 1, 3], 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add three new methods for `TerraModel`s:

- `nearest_neighbors` for `n` nearest neighbours, giving both the point index and distance;
- `nearest_indices`, giving just the `n` nearest point indices; and
- `nearest_index`, giving just the index of the nearest lateral point.

These will be useful for interpolation routine, to come.

### For all pull requests:

* [x] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have created a testcase for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/changes](../blob/main/doc/changes) directory that will inform other users of my change.
