### PR TITLE
Add method to plot a layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ scipy = "^1.6"
 netcdf4 = "^1"
 matplotlib = "^3.5"
 scikit-learn = "^1.1.2"
+Cartopy = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.5.0"

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -1,0 +1,89 @@
+"""
+plot
+====
+
+The `plot` module contains internal functions for performing
+plotting of TerraModels and other classes in terratools.
+"""
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.interpolate
+import scipy.stats
+
+
+def layer_grid(lon, lat, radius, values, delta=None, extent=(-180, 180, -90, 90),
+        label=None, method="nearest", **subplots_kwargs):
+    """
+    Take a set of arbitrary points in longitude and latitude, each
+    with a different value, and create a grid of these values, which
+    is then plotted on a map.
+
+    :param lon: Set of longitudes in degrees
+    :param lat: Set of latitudes in degrees
+    :param radius: Radius of layer in km
+    :param values: Set of the values taken at each point
+    :param delta: Grid spacing in degrees
+    :param extent: Tuple giving min longitude, max longitude, min latitude
+        and max latitude (all in degrees), defining the region to plot
+    :param label: Label for values; e.g. "Temperature / K"
+    :param method: Can be one of:
+        - "nearest": nearest neighbour only;
+        - "mean": mean of all values within each grid point
+    :param **kwargs: Extra keyword arguments passed to
+        `matplotlib.pyplot.subplots`
+    :returns: tuple of figure and axis handles, respectively
+    """
+    fig, ax = plt.subplots(
+        subplot_kw={'projection': ccrs.EqualEarth()},
+        **subplots_kwargs
+    )
+
+    if len(extent) != 4:
+        raise ValueError("extent must contain four values")
+    elif extent[1] <= extent[0]:
+        raise ValueError("maximum longitude must be more than minimum; have" +
+            f"min = {extent[0]} and max = {extent[1]}")
+    elif extent[3] <= extent[2]:
+        raise ValueError("maximum latitude must be more than minimum; have" +
+            f"min = {extent[2]} and max = {extent[3]}")
+
+    minlon, maxlon, minlat, maxlat = extent
+
+    if delta is None:
+        lonrange = maxlon - minlon
+        latrange = maxlat - minlat
+        max_range = max(lonrange, latrange)
+        delta = max_range/200
+    elif delta <= 0:
+            raise ValueError("delta must be more than 0")
+
+    grid_lons = np.arange(minlon, maxlon, delta)
+    grid_lats = np.arange(minlat, maxlat, delta)
+    grid_lon, grid_lat = np.meshgrid(grid_lons, grid_lats)
+
+    if method == "nearest":
+        grid = scipy.interpolate.griddata((lon, lat), values, (grid_lon, grid_lat),
+            method="nearest")
+    elif method == "mean":
+        grid, _, _, _ = scipy.stats.binned_statistic_2d(lon, lat, values,
+            bins=[grid_lons, grid_lats])
+        grid = np.transpose(grid)
+    else:
+        raise ValueError(f"unsupported method '{method}")
+
+    grid = np.flip(grid, axis=0)
+
+    transform = ccrs.PlateCarree()
+
+    contours = ax.imshow(grid, transform=transform)
+    ax.set_title(f'Radius {int(radius)} km')
+    ax.set_xlabel(f'{label}', fontsize=12)
+
+    cbar = plt.colorbar(contours, ax=ax, orientation='horizontal', pad=0.05,
+        aspect=30, shrink=0.5, label=(label if label is not None else ""))
+
+    ax.coastlines()
+
+    return fig, ax

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,42 @@
+import unittest
+import numpy as np
+
+from cartopy.mpl.geoaxes import GeoAxesSubplot
+from matplotlib.figure import Figure
+
+from terratools import plot
+
+class TestLayerGrid(unittest.TestCase):
+    def test_layer_grid_errors(self):
+        n = 20
+        lon = 360*np.random.rand(n)
+        lat = 180*(np.random.rand(n) - 0.5)
+        radius = 4000
+        values = np.random.rand(n)
+
+        with self.assertRaises(ValueError):
+            plot.layer_grid(lon, lat, radius, values, extent=(1, 2, 3))
+        with self.assertRaises(ValueError):
+            plot.layer_grid(lon, lat, radius, values, extent=(2, 1, 1, 2))
+        with self.assertRaises(ValueError):
+            plot.layer_grid(lon, lat, radius, values, extent=(1, 2, 2, 1))
+
+        with self.assertRaises(ValueError):
+            plot.layer_grid(lon, lat, radius, values, delta=-1)
+
+        with self.assertRaises(ValueError):
+            plot.layer_grid(lon, lat, radius, values, method="unknown method")
+
+    def test_layer_grid(self):
+        """Just test that no errors are thrown when creating a plot and
+        that we return the right things"""
+        n = 20
+        lon = 360*np.random.rand(n)
+        lat = 180*(np.random.rand(n) - 0.5)
+        radius = 4000
+        values = np.random.rand(n)
+
+        fig, ax = plot.layer_grid(lon, lat, radius, values)
+
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, GeoAxesSubplot)

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -3,6 +3,9 @@ import unittest
 import numpy as np
 import os
 
+from cartopy.mpl.geoaxes import GeoAxesSubplot
+from matplotlib.figure import Figure
+
 from terratools import terra_model
 from terratools.terra_model import TerraModel
 
@@ -41,7 +44,6 @@ def read_test_lateral_points():
     -2° to 2 ° in longitude and latitude"""
     dir = os.path.dirname(__file__)
     file = os.path.join(dir, "data", "TERRA_grid_lon-2_2_lat-2_2.txt")
-    print(file)
     data = np.loadtxt(file, dtype=np.float32)
     lon = data[:,0]
     lat = data[:,1]
@@ -406,7 +408,6 @@ class TestTerraModelEvaluate(unittest.TestCase):
         u_xyz[0,0,:] = [1, 2, 3]
         u_xyz[0,1,:] = [10, 20, 30]
         u_xyz[0,2,:] = [-2, -4, 10]
-        print(model.evaluate(1.9, 0.1, 1, "u_xyz"))
         self.assertTrue(np.all(model.evaluate(1.9, 0.1, 1, "u_xyz", method="nearest") == [-2, -4, 10]))
 
 
@@ -438,6 +439,37 @@ class TestBoundingIndices(unittest.TestCase):
     def test_equal(self):
         self.assertCountEqual(terra_model._bounding_indices(-3, [-4, -3, -2]),
             (1, 1), 2)
+
+
+class TestPlotLayer(unittest.TestCase):
+    def test_errors(self):
+        model = dummy_model(with_fields=True)
+
+        with self.assertRaises(ValueError):
+            model.plot_layer("t")
+
+        with self.assertRaises(ValueError):
+            model.plot_layer("t", index=-1)
+        with self.assertRaises(ValueError):
+            model.plot_layer("t", index=len(model.get_radii())+1)
+
+    def test_plot_layer_radius(self):
+        model = dummy_model(with_fields=True)
+        fig, ax = model.plot_layer("t", 4000, show=False)
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, GeoAxesSubplot)
+
+    def test_plot_layer_depth(self):
+        model = dummy_model(with_fields=True)
+        fig, ax = model.plot_layer("t", 100, depth=True, show=False)
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, GeoAxesSubplot)
+
+    def test_plot_layer_index(self):
+        model = dummy_model(with_fields=True)
+        fig, ax = model.plot_layer("t", index=2, depth=True, show=False)
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, GeoAxesSubplot)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `TerraModel.plot_layer` function to plot a single layer of a field
within a `TerraModel`.  This is currently limited to the nearest layer,
but in future should allow for arbitrary radii to be specified.

* [x] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have created a testcase for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/changes](../blob/main/doc/changes) directory that will inform other users of my change.
