### PR TITLE
Fix reading of NetCDF files with extra variables

### DIFF
--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1020,9 +1020,16 @@ def _variable_names_from_field(field):
 
 def _field_name_from_variable(field):
     """
-    Return the TerraModel field name of a NetCDF file variable name
+    Return the TerraModel field name of a NetCDF file variable name.
+
+    If there is no field name associated with this variable name,
+    return ``None``.
     """
-    return _VARIABLE_NAME_TO_FIELD_NAME[field]
+    try:
+        field_name = _VARIABLE_NAME_TO_FIELD_NAME[field]
+    except KeyError:
+        field_name = None
+    return field_name
 
 
 def _check_field_name(field):

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -90,6 +90,7 @@ class TestTerraModelHelpers(unittest.TestCase):
     def test_field_name_from_variable(self):
         """Translation of NetCDF variable name to field name"""
         self.assertEqual(terra_model._field_name_from_variable("temperature"), "t")
+        self.assertEqual(terra_model._field_name_from_variable("absent field"), None)
 
     def test_check_field_name(self):
         self.assertEqual(terra_model._check_field_name("vp"), None)


### PR DESCRIPTION
NetCDF files which contain any variables which have unexpected
names previously meant that `terra_model._field_name_from_variable`
raised a `KeyError`.  Update the function to return `None` instead
when given a NetCDF variable name which we are not expecting to
read.

This was encountered when using `convert_files.convert` to update
old-format NetCDF files without the `ncks` program, which left
old variables in files which are now unexpected.

Although one could argue that requiring files do not have extra,
unexpected variables is a good feature of the reader, implementing
the behaviour introduced by this commit does mean that old code
should be able to continue to read newer file versions which only
add new variables.


### For all pull requests:

* [x] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.


