### PR TITLE
Make cartopy an optional dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,3 +56,26 @@ jobs:
     - name: test
       run: |
         PYTHON=python ./test.sh
+
+  test_cartopy:
+    name: Test no Cartopy
+    runs-on: [ubuntu-20.04]
+
+    strategy:
+      matrix:
+        python-versions: ['3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-versions }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-versions }}
+    - name: setup
+      run: |
+        python -m pip install --upgrade pip
+        python --version
+        python -m pip install -e .
+    - name: test
+      run: |
+        python -m unittest discover ./tests

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before installing TerraTools, first install and/or upgrade your version of pip:
 ```
 python -m ensurepip --upgrade
 ```
-After that, please make sure you have a working installation of [Cartopy](https://scitools.org.uk/cartopy/docs/latest/installing.html), as installation of Cartopy using pip requires [additional dependencies are met first](https://scitools.org.uk/cartopy/docs/latest/installing.html). On Mac machines, you may find that after you follow the instructions on that site, you still need to add the following command to your `~/.bashrc` or equivalent:
+If you want to use the map plotting functions (such as `TerraModel.plot_layer`), make sure you have a working installation of [Cartopy](https://scitools.org.uk/cartopy/docs/latest/installing.html), as installation of Cartopy using pip requires [additional dependencies are met first](https://scitools.org.uk/cartopy/docs/latest/installing.html). On Mac machines, you may find that after you follow the instructions on that site, you still need to add the following command to your `~/.bashrc` or equivalent:
 ```
 export DYLD_LIBRARY_PATH=/opt/homebrew/opt/geos/lib/
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ scipy = "^1.6"
 netcdf4 = "^1"
 matplotlib = "^3.5"
 scikit-learn = "^1.1.2"
-cartopy = {version = "^0.21.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.5.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
+cartopy = "^0.21.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,13 @@ scipy = "^1.6"
 netcdf4 = "^1"
 matplotlib = "^3.5"
 scikit-learn = "^1.1.2"
-Cartopy = "^0.21.0"
+cartopy = {version = "^0.21.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.5.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^22.12.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -3,11 +3,20 @@ This submodule contains internal functions for performing
 plotting of TerraModels and other classes in terratools.
 """
 
-import cartopy.crs as ccrs
+_CARTOPY_INSTALLED = True
+_CARTOPY_NOT_INSTALLED_EXCEPTION = None
+
+try:
+    import cartopy.crs as ccrs
+except ImportError as exception:
+    _CARTOPY_INSTALLED = False
+    _CARTOPY_NOT_INSTALLED_EXCEPTION = exception
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate
 import scipy.stats
+import sys
 
 
 def layer_grid(
@@ -41,6 +50,10 @@ def layer_grid(
         `matplotlib.pyplot.subplots`
     :returns: tuple of figure and axis handles, respectively
     """
+    if not _CARTOPY_INSTALLED:
+        sys.stderr.write("layer_grid require cartopy to be installed")
+        raise _CARTOPY_NOT_INSTALLED_EXCEPTION
+
     fig, ax = plt.subplots(
         subplot_kw={"projection": ccrs.EqualEarth()}, **subplots_kwargs
     )

--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,7 @@ fi
 # Quietly install terratools in development mode
 echo "Installing TerraTools in development mode ..."
 $PYTHON -m pip install -q -e .
+$PYTHON -m pip install -q cartopy
 echo ""
 
 function testit {

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,13 +1,46 @@
 import unittest
 import numpy as np
 
-from cartopy.mpl.geoaxes import GeoAxesSubplot
+_CARTOPY_INSTALLED = True
+try:
+    from cartopy.mpl.geoaxes import GeoAxesSubplot
+except ImportError as exception:
+    _CARTOPY_INSTALLED = False
+
 from matplotlib.figure import Figure
 
 from terratools import plot
 
 
+def needs_cartopy(func):
+    """
+    Decorator which wraps a test function taking an instance of
+    `unittest.TestCase` and does not run the test case if Cartopy is not
+    installed.
+    """
+    if _CARTOPY_INSTALLED:
+        return func
+    else:
+
+        def returns_none(self):
+            return None
+
+        return returns_none
+
+
 class TestLayerGrid(unittest.TestCase):
+    def test_layer_grid_no_cartopy(self):
+        n = 20
+        lon = 360 * np.random.rand(n)
+        lat = 180 * (np.random.rand(n) - 0.5)
+        radius = 4000
+        values = np.random.rand(n)
+
+        if not _CARTOPY_INSTALLED:
+            with self.assertRaises(ImportError):
+                plot.layer_grid(lon, lat, radius, values, extent=(1, 2, 3))
+
+    @needs_cartopy
     def test_layer_grid_errors(self):
         n = 20
         lon = 360 * np.random.rand(n)
@@ -28,6 +61,7 @@ class TestLayerGrid(unittest.TestCase):
         with self.assertRaises(ValueError):
             plot.layer_grid(lon, lat, radius, values, method="unknown method")
 
+    @needs_cartopy
     def test_layer_grid(self):
         """Just test that no errors are thrown when creating a plot and
         that we return the right things"""

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -3,7 +3,12 @@ import unittest
 import numpy as np
 import os
 
-from cartopy.mpl.geoaxes import GeoAxesSubplot
+_CARTOPY_INSTALLED = True
+try:
+    from cartopy.mpl.geoaxes import GeoAxesSubplot
+except ImportError:
+    _CARTOPY_INSTALLED = False
+
 from matplotlib.figure import Figure
 
 from terratools import terra_model
@@ -478,35 +483,37 @@ class TestBoundingIndices(unittest.TestCase):
         )
 
 
-class TestPlotLayer(unittest.TestCase):
-    def test_errors(self):
-        model = dummy_model(with_fields=True)
+if _CARTOPY_INSTALLED:
 
-        with self.assertRaises(ValueError):
-            model.plot_layer("t")
+    class TestPlotLayer(unittest.TestCase):
+        def test_errors(self):
+            model = dummy_model(with_fields=True)
 
-        with self.assertRaises(ValueError):
-            model.plot_layer("t", index=-1)
-        with self.assertRaises(ValueError):
-            model.plot_layer("t", index=len(model.get_radii()) + 1)
+            with self.assertRaises(ValueError):
+                model.plot_layer("t")
 
-    def test_plot_layer_radius(self):
-        model = dummy_model(with_fields=True)
-        fig, ax = model.plot_layer("t", 4000, show=False)
-        self.assertIsInstance(fig, Figure)
-        self.assertIsInstance(ax, GeoAxesSubplot)
+            with self.assertRaises(ValueError):
+                model.plot_layer("t", index=-1)
+            with self.assertRaises(ValueError):
+                model.plot_layer("t", index=len(model.get_radii()) + 1)
 
-    def test_plot_layer_depth(self):
-        model = dummy_model(with_fields=True)
-        fig, ax = model.plot_layer("t", 100, depth=True, show=False)
-        self.assertIsInstance(fig, Figure)
-        self.assertIsInstance(ax, GeoAxesSubplot)
+        def test_plot_layer_radius(self):
+            model = dummy_model(with_fields=True)
+            fig, ax = model.plot_layer("t", 4000, show=False)
+            self.assertIsInstance(fig, Figure)
+            self.assertIsInstance(ax, GeoAxesSubplot)
 
-    def test_plot_layer_index(self):
-        model = dummy_model(with_fields=True)
-        fig, ax = model.plot_layer("t", index=2, depth=True, show=False)
-        self.assertIsInstance(fig, Figure)
-        self.assertIsInstance(ax, GeoAxesSubplot)
+        def test_plot_layer_depth(self):
+            model = dummy_model(with_fields=True)
+            fig, ax = model.plot_layer("t", 100, depth=True, show=False)
+            self.assertIsInstance(fig, Figure)
+            self.assertIsInstance(ax, GeoAxesSubplot)
+
+        def test_plot_layer_index(self):
+            model = dummy_model(with_fields=True)
+            fig, ax = model.plot_layer("t", index=2, depth=True, show=False)
+            self.assertIsInstance(fig, Figure)
+            self.assertIsInstance(ax, GeoAxesSubplot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This means that users must install cartopy separately if they want to
make maps which use cartopy, via `pip` or otherwise.

Update the test script to install cartopy unconditionally.  A future
commit will add a test for the correct behaviour (an `ImportError`)
when trying to call a function which relies on cartopy.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. 

*Describe what you did in this PR and why you did it.*

### For all pull requests:

* [x] I have run the 
[`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have created a testcase for the new feature/benchmark in the 
[tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/changes](../blob/main/doc/changes) directory that will inform other users of my change.
