### PR TITLE
Black version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-versions }}
     - name: make indent
       run: |
-        python -m pip install black
+        python -m pip install black==22.12
         ./contrib/utilities/indent
         git diff > changes-astyle.diff
     - name: archive indent results

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -15,8 +15,8 @@ fi
 # with up to 10 in parallel
 echo "--- Indenting all TerraTools header and source files"
 
-# Run black autoformatter
-find terratools contrib tests examples \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'black "$@"' _ {}
+# Run black autoformatter, require version from 2022
+find terratools contrib tests examples \( -name '*.py' \) -print | xargs -n 1 -P 10 -I {} bash -c 'black --required-version 22 "$@"' _ {}
 
 # remove execute permission on source files:
 find terratools contrib tests examples \( -name '*.py' \) -print | xargs -n 50 -P 10 chmod -x


### PR DESCRIPTION
This PR forces github actions to use black 22.12 and makes the indent script use version 22.x.