### PR TITLE
Read concatenated files

### DIFF
--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -34,7 +34,6 @@ _SCALAR_FIELDS = {
     "density": "Density [g/cm^3]",
     "qp": "P-wave quality factor [unitless]",
     "qs": "S-wave quality factor [unitless]",
-    "visc": "Viscosity [Pas]",
 }
 
 # These are 'vector' fields which contain more than one component
@@ -66,8 +65,7 @@ _FIELD_NAME_TO_VARIABLE_NAME = {
     "vphi": ("v_bulk",),
     "vp_an": ("vp_anelastic",),
     "vs_an": ("vs_anelastic",),
-    "density": ("density",),
-    "visc": ("viscosity",),
+    "Density": ("density",),
 }
 
 
@@ -983,9 +981,7 @@ class TerraModel:
         return
 
 
-def read_netcdf(
-    files, fields=None, surface_radius=6370.0, test_lateral_points=False, cat=False
-):
+def read_netcdf(files, fields=None, surface_radius=6370.0, test_lateral_points=False):
     """
     Read a TerraModel from a set of NetCDF files.
 
@@ -1012,38 +1008,20 @@ def read_netcdf(
     # Total number of lateral points and number of layers,
     # allowing us to preallocate arrays.  Consistency is checked on the next pass.
     npts_total = 0
-    if not cat:
-        for file_number, file in enumerate(files):
-            nc = netCDF4.Dataset(file)
-            if "nps" not in nc.dimensions:
-                raise ValueError(f"File {file} does not contain the dimension 'nps'")
-            npts_total += nc.dimensions["nps"].size
-
-            _check_version(nc)
-
-            if "depths" not in nc.dimensions:
-                raise ValueError(f"File {file} does not contain the dimension 'Depths'")
-            if file_number == 0:
-                nlayers = nc.dimensions["depths"].size
-                # Take the radii from the first file
-                _r = np.array(surface_radius - nc["depths"][:], dtype=COORDINATE_TYPE)
-        nfiles = len(files)
-    else:
-        file = files
+    for file_number, file in enumerate(files):
         nc = netCDF4.Dataset(file)
         if "nps" not in nc.dimensions:
             raise ValueError(f"File {file} does not contain the dimension 'nps'")
-        if "record" not in nc.dimensions:
-            raise ValueError(f"Expecting concatenated file with dimension 'record'")
-        npts_total = nc.dimensions["nps"].size * nc.dimensions["record"].size
+        npts_total += nc.dimensions["nps"].size
 
         _check_version(nc)
 
         if "depths" not in nc.dimensions:
             raise ValueError(f"File {file} does not contain the dimension 'Depths'")
-        nlayers = nc.dimensions["depths"].size
-        _r = np.array(surface_radius - nc["depths"][:], dtype=COORDINATE_TYPE)
-        nfiles = nc.dimensions["record"].size
+        if file_number == 0:
+            nlayers = nc.dimensions["depths"].size
+            # Take the radii from the first file
+            _r = np.array(surface_radius - nc["depths"][:], dtype=COORDINATE_TYPE)
 
     # Passed to constructor
     _fields = {}
@@ -1052,16 +1030,8 @@ def read_netcdf(
     _c_hist_names = {}
 
     npts_pointer = 0
-
-    if cat:
+    for file_number, file in enumerate(files):
         nc = netCDF4.Dataset(file)
-
-    for file_number in range(nfiles):
-
-        # read in next file if not loading from concatenated file
-        if not cat:
-            file = files[file_number]
-            nc = netCDF4.Dataset(file)
 
         # Check the file has the right things
 
@@ -1084,12 +1054,8 @@ def read_netcdf(
 
         # Assume that the latitudes and longitudes are the same for each
         # depth slice, and so are repeated
-        if not cat:
-            this_slice_lat = nc["latitude"][:]
-            this_slice_lon = nc["longitude"][:]
-        else:
-            this_slice_lat = nc["latitude"][file_number, :]
-            this_slice_lon = nc["longitude"][file_number, :]
+        this_slice_lat = nc["latitude"][:]
+        this_slice_lon = nc["longitude"][:]
 
         _lat[npts_range] = this_slice_lat
         _lon[npts_range] = this_slice_lon
@@ -1125,10 +1091,7 @@ def read_netcdf(
 
             # Handle scalar fields
             if _is_scalar_field(field_name):
-                if not cat:
-                    field_data = nc[var][:]
-                else:
-                    field_data = nc[var][file_number, :]
+                field_data = nc[var][:]
 
                 if field_name not in _fields.keys():
                     _fields[field_name] = np.empty(
@@ -1147,14 +1110,9 @@ def read_netcdf(
                 ncomps = _VECTOR_FIELD_NCOMPS[field_name]
                 uxyz = np.empty((nlayers, npts, ncomps), dtype=VALUE_TYPE)
 
-                if not cat:
-                    uxyz[:, :, 0] = nc["velocity_x"][:]
-                    uxyz[:, :, 1] = nc["velocity_y"][:]
-                    uxyz[:, :, 2] = nc["velocity_z"][:]
-                else:
-                    uxyz[:, :, 0] = nc["velocity_x"][file_number, :]
-                    uxyz[:, :, 1] = nc["velocity_y"][file_number, :]
-                    uxyz[:, :, 2] = nc["velocity_z"][file_number, :]
+                uxyz[:, :, 0] = nc["velocity_x"][:]
+                uxyz[:, :, 1] = nc["velocity_y"][:]
+                uxyz[:, :, 2] = nc["velocity_z"][:]
 
                 if field_name not in _fields.keys():
                     _fields[field_name] = np.empty(
@@ -1205,18 +1163,12 @@ def read_netcdf(
                 nth_comp = nth_comp + 1.0
                 for local_var in vars_to_read:
                     for c in range(ncomps):
-                        if not cat:
-                            nth_comp = nth_comp - nc[local_var][c, :, :]
-                            _fields["c_hist"][:, npts_range, c] = nc[local_var][c, :, :]
-                        else:
-                            nth_comp = nth_comp - nc[local_var][file_number, c, :, :]
-                            _fields["c_hist"][:, npts_range, c] = nc[local_var][
-                                file_number, c, :, :
-                            ]
+                        nth_comp = nth_comp - nc[local_var][c, :, :]
+                        _fields["c_hist"][:, npts_range, c] = nc[local_var][c, :, :]
                     _fields["c_hist"][:, npts_range, -1] = nth_comp[:]
                 _test_composition(_fields["c_hist"][:, npts_range, :])
-        if not cat:  # close only if reading in list of files
-            nc.close()
+
+        nc.close()
         npts_pointer += npts
 
     # Check for need to sort points in increasing radius


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. 

Added capability to read a single netcdf file that is a concatenation of netcdf files of a single time step dump. Such files are create using `ncecat` which is available though netCDF Operators (NCO). This is useful for users who locally store lots of model output, where having a single concatenated netCDF file for each dump is more manageable than having a file for each process for each dump.

### For all pull requests:

* [X] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.

