### PR TITLE
Fix naming and calling conventions for profiles

### DIFF
--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -845,7 +845,7 @@ class TerraModel:
 
         return profile
 
-    def get_1d_profile(self, field, lat, lon):
+    def get_1d_profile(self, field, lon, lat):
         """
         Return the 1d profile of the given field
         at a given latitude and longitude point.

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -826,7 +826,7 @@ class TerraModel:
         """
         return self._radius
 
-    def get_1d_mean(self, field):
+    def mean_1d_profile(self, field):
         """
         Return the mean of the given field at each radius
 

--- a/tests/test_1d_profile.py
+++ b/tests/test_1d_profile.py
@@ -26,7 +26,7 @@ class TestAdiabat(unittest.TestCase):
 
     def test_mean_1d_profile(self):
         t_profile = np.array([5, 5, 5])
-        out_profile = self.m.mean_1d_profilen(field="t")
+        out_profile = self.m.mean_1d_profile(field="t")
 
         self.assertEqual(t_profile[0], out_profile[0], "mean 1d profile failed.")
         self.assertEqual(t_profile[1], out_profile[1], "mean 1d profile failed.")

--- a/tests/test_1d_profile.py
+++ b/tests/test_1d_profile.py
@@ -26,7 +26,7 @@ class TestAdiabat(unittest.TestCase):
 
     def test_mean_1d_profile(self):
         t_profile = np.array([5, 5, 5])
-        out_profile = self.m.get_1d_mean(field="t")
+        out_profile = self.m.mean_1d_profilen(field="t")
 
         self.assertEqual(t_profile[0], out_profile[0], "mean 1d profile failed.")
         self.assertEqual(t_profile[1], out_profile[1], "mean 1d profile failed.")


### PR DESCRIPTION
Rename a function to conform to the convention for methods of `TerraModel` and ensure that the argument order for longitude and latitude is the same everywhere.

- terra_model: Rename `get_1d_mean` to `mean_1d_profile`
- terra_moel: Update coordinate order of `get_1d_profile`
