### PR TITLE
Docs: Add `TerraModel` overview and reference frame page

### DIFF
--- a/docs/images/reference_frames.svg
+++ b/docs/images/reference_frames.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 415 383" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <g transform="matrix(1,0,0,1,-325.781,-168.433)">
+        <g transform="matrix(0.707107,0.707107,-0.707107,0.707107,512,156.242)">
+            <circle cx="161.049" cy="161.049" r="161.049" style="fill:none;stroke:black;stroke-width:3px;"/>
+        </g>
+        <g transform="matrix(1,0,0,-1,516.89,384)">
+            <path d="M0,0L196.912,0" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        </g>
+        <path d="M712.803,388.8L722.403,384L712.803,379.2L712.803,388.8Z" style="fill-rule:nonzero;"/>
+        <g transform="matrix(-0.843157,0.537667,0.537667,0.843157,517.034,383.55)">
+            <path d="M0,0L195.566,0" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,0,209.438)">
+            <path d="M350.403,274.677L344.89,283.885L355.565,282.771L350.403,274.677Z" style="fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0,-1,-1,0,516.89,384)">
+            <path d="M0,0L188.368,0" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,0,-384.336)">
+            <path d="M521.691,580.968L516.89,571.368L512.091,580.968L521.691,580.968Z" style="fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,-1,518.72,420.287)">
+            <path d="M0,36.245L51.716,0L51.716,92.887L0,36.245Z" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;stroke-dasharray:2,2;"/>
+        </g>
+        <g transform="matrix(1,0,0,-1,557.889,328.326)">
+            <g transform="matrix(1,0,0,-1,-232.107,159.892)">
+                <path d="M263.883,145.168L265.983,138.797L259.626,140.94L263.883,145.168Z" style="fill-rule:nonzero;"/>
+                <path d="M231.704,136.318L232.107,129.622L237.222,133.962L231.704,136.318Z" style="fill-rule:nonzero;"/>
+                <path d="M262.6,142.202C256.672,148.171 245.03,159.892 245.03,159.892C245.03,159.892 237.578,142.437 233.992,134.037" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+            </g>
+        </g>
+        <g transform="matrix(0.947917,-0.318518,0.318518,0.947917,572.167,313.988)">
+            <g transform="matrix(0.947917,0.318518,-0.318518,0.947917,-187.191,-216.452)">
+                <path d="M266.765,148.617L273.418,149.478L268.737,154.283L266.765,148.617Z" style="fill-rule:nonzero;"/>
+                <path d="M244.39,159.581C244.39,159.581 260.721,153.897 268.884,151.056" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+            </g>
+        </g>
+        <g transform="matrix(1,0,0,-1,465.829,546.309)">
+            <path d="M52.024,324.625C50.997,324.238 49.974,323.75 48.958,323.163C-20.05,283.275 -12.887,14.696 50.261,1.712C50.911,1.579 51.609,1.405 52.024,0" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        </g>
+        <g transform="matrix(0,-1,-1,0,674.639,437.187)">
+            <path d="M52.024,324.625C50.997,324.238 49.974,323.75 48.958,323.163C-20.05,283.275 -12.887,14.696 50.261,1.712C50.911,1.579 51.609,1.405 52.024,0" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        </g>
+        <text x="327.605px" y="502.302px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">x</text>
+        <text x="727.105px" y="390.841px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">y</text>
+        <text x="510.89px" y="180.841px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">z</text>
+        <g transform="matrix(1,0,0,1,1,1)">
+            <text x="604.002px" y="322.905px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">e</text>
+        </g>
+        <g transform="matrix(1,0,0,1,0,1)">
+            <text x="547.059px" y="293.405px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">n</text>
+            <text x="591.591px" y="298.905px" style="font-family:'HelveticaNeue-BoldItalic', 'Helvetica Neue';font-weight:700;font-style:italic;font-size:24px;">u</text>
+        </g>
+        <g transform="matrix(0.170747,-0.985315,0.985315,0.170747,0,0)">
+            <text x="-307.275px" y="510.887px" style="font-family:'HelveticaNeue-Italic', 'Helvetica Neue';font-style:italic;font-size:20px;">Prime meridian</text>
+        </g>
+        <g transform="matrix(0.999973,0.00737661,-0.00737661,0.999973,0,0)">
+            <text x="485.185px" y="453.572px" style="font-family:'HelveticaNeue-Italic', 'Helvetica Neue';font-style:italic;font-size:20px;">Equator</text>
+        </g>
+    </g>
+</svg>

--- a/docs/model.md
+++ b/docs/model.md
@@ -1,0 +1,108 @@
+The main interface for dealing with TERRA models is the `TerraModel` class
+which represents an instance in time within a TERRA simulation.
+
+## `terratools.terra_model`
+
+The `terra_model` module within `terratools` contains all the functionality
+related to using `TerraModel`s.  Load it with
+`from terratools import terra_model`.
+
+## Reading NetCDF files
+`terratools` defines a NetCDF file format [REF TO FILE FORMAT], which can be
+read using [terra_model.read_netcdf][terratools.terra_model.read_netcdf].
+
+`terra_model.read_netcdf` will read these and return a `TerraModel` object.
+
+## `TerraModel`
+The `TerraModel` class holds the information about a mantle convection
+simulation at a single time snapshot.  More details about `TerraModel`s can
+be found in the [class docstring][terratools.terra_model.TerraModel].
+
+At a minimum, a `TerraModel` instance will usually contain information about:
+- the temperature field $T$ at all points (called `"t"` within `terratools`); and
+- the flow field $u$ at all points (called `"u_xyz"` if in the global Cartesian
+  [reference frame](reference_frames.md)).
+
+### Fields
+Depending on the contents of the model file, it may contain some of the
+following fields:
+
+- Scalar fields:
+  - `"t"`: Temperature field [K]
+  - `"c"`: Scalar composition field [unitless]
+  - `"p"`: Pressure field [GPa]
+  - `"vp"`: P-wave velocity (elastic) [km/s]
+  - `"vs"`: S-wave velocity (elastic) [km/s]
+  - `"vphi"`: Bulk sound velocity (elastic) [km/s]
+  - `"vp_an"`: P-wave velocity (anelastic) [km/s]
+  - `"vs_an"`: S-wave velocity (anelastic) [km/s]
+  - `"vphi_an"`: Bulk sound velocity (anelastic) [km/s]
+  - `"density"`: Density [g/cm^3]
+  - `"qp"`: P-wave quality factor [unitless]
+  - `"qs"`: S-wave quality factor [unitless]
+  - `"visc"`: Viscosity [Pa s]
+- Vector fields:
+  - `"u_xyz"`: Flow field in Cartesian coordinates (three components) [m/s]
+  - `"u_enu"`: Flow field in local geographic coordinates (three components) [m/s]
+  - `"c_hist"`: Composition histogram [unitles]
+
+### Field coordinates
+All fields are defined in space by two indices:
+- The first index gives the layer number, starting from `0` at the lowest part of
+  the model.  Layer radii can be given using
+  [terra_model.TerraModel.get_radii][terratools.terra_model.TerraModel.get_radii].
+  For a model `m`, the `i`th layer is therfore at radius `m.get_radii()[i]`.
+- The second index gives the lateral
+  ([global geographic](reference_frames#Global-geographic)) position on the unit
+  sphere of the point.
+  [terra_model.TerraModel.get_lateral_points][terratools.terra_model.TerraModel.get_lateral_points]
+  returns a tuple of `lon, lat`, where `lon` and `lat` are both the global
+  geographic coordinates of each lateral point.  Therefore the coordinates of
+  the `j`th lateral point for model `m` are given by
+  ```python
+  lon, lat = m.get_lateral_points()
+  lon[j], lat[j]
+  ```
+
+In this way, what is really a 3D field of positions is represented as only a
+2D array of values.
+
+Scalar fields are 2D arrays, whose first index is that of the layer, and the second
+is that of the lateral point.  So to get the value of the temperature $T$ at
+the bottom layer (index `0`) and the last lateral point for model `m`, you would do
+`m.get_field("t")[0,-1]`.
+
+Vector fields are 3D arrays.  Their first two indices are the same as for scalar
+fields, but the final index gives the component of the field at that position.
+For example, to get the radial components of flow (local up) for the 10th layer,
+do `m.get_field("u_enu")[9,:,2]`, noting that the 'up' component is at the third
+index of the last dimension.
+
+The fields returned by `get_field` are what is stored inside the `TerraModel`
+and editing the arrays (in fact NumPy arrays) will update the model.
+
+Fields can be created or replaced with
+[m.new_field][terratools.terra_model.TerraModel.new_field] and
+[m.set_field][terratools.terra_model.TerraModel.set_field], and the fields
+currently present in a model can be found with
+[m.field_names][terratools.terra_model.TerraModel.field_names].
+
+### Field evaluation
+One of the most common requirements of a `TerraModel` `m` is to find out what the
+value of some field is at an arbitrary point within the model.  This is done
+with [m.evaluate][terratools.terra_model.TerraModel.evaluate].  Evaluation
+can be done by finding the nearest neighbour to the point of interest, or using
+interpolation.
+
+### Plotting
+Fields can be plotted in various ways:
+- Cross sections can be made with [TerraModel.plot_section][terratools.terra_model.TerraModel.plot_section]
+- Depth slices can be made with [TerraModel.plot_layer][terratools.terra_model.TerraModel.plot_layer].
+- Spherical harmonic power by degree across all layers can be plotted with
+  [TerraModel.plot_spectral_heterogeneity][terratools.terra_model.TerraModel.plot_spectral_heterogeneity]
+
+### Spherical harmonics
+Spherical harmonics can be analysed for fields with the
+[m.cal_spherical_harmonics][terratools.terra_model.TerraModel.calc_spherical_harmonics]
+function.  These can then be retrieved using
+[m.get_spherical_harmonics][terratools.terra_model.TerraModel.get_spherical_harmonics].

--- a/docs/reference_frames.md
+++ b/docs/reference_frames.md
@@ -1,0 +1,45 @@
+This page describes the different reference frames used by TERRA and
+`terratools`.
+
+## Accessing individual components
+In both cases below, individual elements in fields are accessed
+
+## Global geographic frame
+Most commonly, you will interact with points based on their geographic
+position.  This is given in terms of
+- the longitude `lon`, in °;
+- the latitude `lat`, in °; and
+- the radius `r`, in km.
+
+Within `terratools`, when geographic coordinates are used as arguments
+or return values from functions, they will be in the order `lon, lat, r`.
+
+(Many functions accept the `depth=True` keyword argument which converts the
+value of `r` given (or returned) into a depth below the model surface.)
+
+The lateral points of the TERRA model mesh are given by
+[terra_model.TerraModel.get_lateral_points][terratools.terra_model.TerraModel.get_lateral_points],
+while [terra_model.TerraModel.get_radii][terratools.terra_model.TerraModel.get_radii]
+returns the radii of the layers in the mesh.
+
+## Global Cartesian frame
+TERRA internally uses the global Cartesian reference frame, whose origin
+lies at the centre of the Earth or spherical body being modelled.  In this
+system, the following directions are defined:
+- $x$ is from the centre towards the point where the equator and prime
+  meridian runs (i.e., a longitude of 0° and latitude of 0°).
+- $y$ is from the centre towards 90° east, through the equator (longitude
+  90° and latitude 0°).
+- $z$ is from the centre towards the north pole (latitude 90°).
+
+Fields in a [TerraModel][terratools.terra_model.TerraModel] such as `"u_xyz"`
+use this reference frame.
+
+## Local geographic reference frame
+Some fields such as `"u_enu"` use a local reference frame defined by the
+directions:
+- `e`: local east direction
+- `n`: local north direction
+- `u`: radial direction, pointing away from the centre of the Earth
+
+![Reference frames used by terratools](images/reference_frames.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,9 @@ nav:
     - Home: index.md
     - About: about.md
     - TerraTools fundamentals:
-        - Model interrogation: model.md
+        - Model objects: model.md
         - Physical properties: properties.md
+        - Reference frames: reference_frames.md
     - Examples: reference_examples/
     - Code Reference: reference/
 


### PR DESCRIPTION
This is a stab at an overview page for `TerraModel` which introduces some of the 
conventions and lists some of the functionality.  If there are other things which 
should go in, it would be useful to know.

Along the way, it struck me that it would be easiest to explain the different 
coordinate systems, so I have made a page for that.

I don't know if SVG images can be included, but I have tried that.

- Add an overview page for `TerraModel`s which refers to the
  autogenerated docstrings.
- Add a page about the reference frames used within terratools
  with an SVG figure.
