### PR TITLE
TerraModel.plot_section: Try to fix intermittent random test failures

### DIFF
--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1457,6 +1457,9 @@ class TerraModel:
         if minradius >= maxradius:
             raise ValueError("minradius must be less than maxradius")
 
+        # Allow us to plot at least two points
+        if (maxradius - minradius) / 2 < delta_radius:
+            delta_radius = (maxradius - minradius) / 2
         radii = np.arange(minradius, maxradius, delta_radius)
         distances = np.arange(0, distance, delta_distance)
 

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -644,6 +644,16 @@ class TestPlotSection(unittest.TestCase):
         self.assertIsInstance(fig, Figure)
         self.assertIsInstance(ax, PolarAxes)
 
+    def test_plot_section_one_layer(self):
+        model = dummy_model(with_fields=True)
+        radii = model.get_radii()
+        radius_diff = radii[-1] - radii[0]
+        fig, ax = model.plot_section(
+            "t", 10, 20, 30, 120, delta_radius=radius_diff + 1, show=False
+        )
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, PolarAxes)
+
 
 if _CARTOPY_INSTALLED:
 


### PR DESCRIPTION
Sometimes `test_plot_section` errors because too few points are
calculated with the default radial spacing.  ~Try to fix this by
increasing the number of layers in the random model created.~ Fix this within `TerraModel.plot_section` by accounting for this possibiliy, and test the fix works.
