### PR TITLE
removed deprecated watch feature from mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,6 @@ plugins:
                 selection_opt: true
                 rendering_opt: "value"
                 docstring_style: "sphinx"
-    watch:
-    - terratools
 - gen-files:
     scripts:
     - docs/gen_ref_pages.py


### PR DESCRIPTION
Fixes readthedocs build failing as a result of mkdocstrings breaking changes:
`https://github.com/mkdocstrings/mkdocstrings/releases/tag/0.23.0`
