### PR TITLE
Allowing plotting to existing axes

### DIFF
--- a/examples/example_cross_section.py
+++ b/examples/example_cross_section.py
@@ -58,7 +58,7 @@ interpolation, and only plot the field near the surface:
 """
 
 # %%
-fig, ax = model.plot_section(
+fig, ax, cbar = model.plot_section(
     "t",
     lon=0,
     lat=-30,

--- a/examples/example_plot_flowfield.py
+++ b/examples/example_plot_flowfield.py
@@ -66,7 +66,7 @@ geographic vector is defined as positive [east, north, up].
 """
 
 # %%
-fig, ax, cbar = plt.subplots()
+fig, ax = plt.subplots()
 max_zvel = np.nanmax(flow_velocity[2, :, :])
 psm = ax.pcolor(
     glon, glat, flow_velocity[2, :, :], vmin=-max_zvel, vmax=max_zvel, cmap="seismic"

--- a/examples/example_plot_flowfield.py
+++ b/examples/example_plot_flowfield.py
@@ -66,7 +66,7 @@ geographic vector is defined as positive [east, north, up].
 """
 
 # %%
-fig, ax = plt.subplots()
+fig, ax, cbar = plt.subplots()
 max_zvel = np.nanmax(flow_velocity[2, :, :])
 psm = ax.pcolor(
     glon, glat, flow_velocity[2, :, :], vmin=-max_zvel, vmax=max_zvel, cmap="seismic"

--- a/examples/example_plot_map.py
+++ b/examples/example_plot_map.py
@@ -42,7 +42,7 @@ Plotting depth slices in terratools is very easy. First we show a basic plot for
 # %%
 
 # Note we set depth=True to define the depth as 2800
-fig, ax = model.plot_layer(field="t", radius=2800, depth=True, show=False)
+fig, ax, cbar = model.plot_layer(field="t", radius=2800, depth=True, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature field at 2800 km depth")
 plt.show()
@@ -58,7 +58,7 @@ We can do the same thing with other scalar fields such as the bulk composition.
 model.calc_bulk_composition()
 
 # Note bulk composition is in the "c" field.
-fig, ax = model.plot_layer(field="c", radius=2800, depth=True, show=False)
+fig, ax, cbar = model.plot_layer(field="c", radius=2800, depth=True, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Bulk composition at 2800 km depth")
 plt.show()
@@ -71,7 +71,7 @@ Rather than defining a radius, we can give an index for the layer we want to plo
 
 # %%
 
-fig, ax = model.plot_layer(field="t", index=10, show=False)
+fig, ax, cbar = model.plot_layer(field="t", index=10, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature at the index 10.")
 plt.show()
@@ -84,7 +84,9 @@ We can also change the sampling resolution by varying the delta argument.
 # %%
 
 # plot with intervals of 5 degrees on longitude and latitude.
-fig, ax = model.plot_layer(field="t", radius=2800, depth=True, delta=5, show=False)
+fig, ax, cbar = model.plot_layer(
+    field="t", radius=2800, depth=True, delta=5, show=False
+)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature on a 5$^{\circ}$ grid at 2800 km depth.")
 plt.show()
@@ -105,7 +107,7 @@ max_la = 30
 
 region = (min_lo, max_lo, min_la, max_la)
 
-fig, ax = model.plot_layer(
+fig, ax, cbar = model.plot_layer(
     field="t", radius=2800, depth=True, show=False, extent=region
 )
 fig.set_size_inches(8, 6)

--- a/examples/example_plume_detect.py
+++ b/examples/example_plume_detect.py
@@ -1,6 +1,6 @@
 # %% [markdown]
 """
-# example_add_adiabat
+# example_plume_detect
 
 This example demonstrates how to read in terra output in NetCDF format
 and detect plumes based on temperature and radial velocity.

--- a/examples/example_spherical_harmonics.py
+++ b/examples/example_spherical_harmonics.py
@@ -72,7 +72,7 @@ We can plot the power spectra of the for fields as a function of depth using:
 """
 # %%
 
-fig, ax = model.plot_spectral_heterogeneity("c", lyrmin=0, lyrmax=-1, show=False)
+fig, ax, cmap = model.plot_spectral_heterogeneity("c", lyrmin=0, lyrmax=-1, show=False)
 plt.show()
 
 # %% [markdown]

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -43,6 +43,8 @@ def layer_grid(
     with a different value, and create a grid of these values, which
     is then plotted on a map.
 
+    :param fig: figure handle
+    :param ax: axis handle
     :param lon: Set of longitudes in degrees
     :param lat: Set of latitudes in degrees
     :param radius: Radius of layer in km
@@ -159,6 +161,12 @@ def plot_section(
     """
     Create a plot of a cross-section.
 
+    :param fig: figure handle
+    :type fig: matplotlib.figure.Figure
+
+    :param ax: axis handle
+    :type ax: matplotlib.axes._axes.Axes
+
     :param distances: Distances along cross section, given as the angle
         subtended at the Earth's centre between the starting and
         end points of the section, in degrees.
@@ -186,6 +194,9 @@ def plot_section(
 
     :returns: figure and axis handles
     """
+
+    if fig==None or ax==None:
+        fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
 
     distances_radians = np.radians(distances)
     min_distance = np.min(distances_radians)

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -225,6 +225,8 @@ def spectral_heterogeneity(
     savepath,
     lyrmin,
     lyrmax,
+    fig,
+    ax,
     **subplots_kwargs,
 ):
     """
@@ -238,15 +240,18 @@ def spectral_heterogeneity(
     :param savepath: path under which to save figure
     :param lyrmin: minimum layer to plot
     :param lyrmax: maximum layer to plot
+    :param fig: figure handle
+    :param ax: axis handle
     :param **subplots_kwargs: Extra keyword arguments passed to
             `matplotlib.pyplot.subplots`
-    :returns: tuple of figure and axis handles, respectively
+    :returns: tuple of figure, axis and cbar handles, respectively
     """
 
     logged = np.log(indat[lyrmin:lyrmax, lmin : lmax + 1])
     deps = depths[lyrmin:lyrmax]
 
-    fig, ax = plt.subplots(figsize=(8, 6), **subplots_kwargs)
+    if fig==None or ax==None:
+        fig, ax = plt.subplots(figsize=(8, 6), **subplots_kwargs)
 
     plotmin = np.min(logged)
     plotmax = np.max(logged)
@@ -272,7 +277,7 @@ def spectral_heterogeneity(
             f"{savepath}/powers_{title}.pdf", format="pdf", dpi=200, bbox_inches="tight"
         )
 
-    return fig, ax
+    return fig, ax, cbar
 
 
 def plumes_3d(

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -22,8 +22,6 @@ import sys
 
 
 def layer_grid(
-    fig,
-    ax,
     lon,
     lat,
     radius,
@@ -36,6 +34,8 @@ def layer_grid(
     cmap=None,
     vmin=None,
     vmax=None,
+    fig=None,
+    ax=None,
     **subplots_kwargs,
 ):
     """
@@ -43,8 +43,6 @@ def layer_grid(
     with a different value, and create a grid of these values, which
     is then plotted on a map.
 
-    :param fig: figure handle
-    :param ax: axis handle
     :param lon: Set of longitudes in degrees
     :param lat: Set of latitudes in degrees
     :param radius: Radius of layer in km
@@ -61,6 +59,11 @@ def layer_grid(
         This works around an issue with Cartopy when
         installed in certain situations.  See
         https://github.com/SciTools/cartopy/issues/879 for details.
+    :param cmap: colour map
+    :param vmin: minimum value to show on plot
+    :param vamx: maximum value to show on plot
+    :param fig: figure handle
+    :param ax: axis handle
     :param **subplots_kwargs: Extra keyword arguments passed to
         `matplotlib.pyplot.subplots`
     :returns: tuple of figure and axis handles, respectively
@@ -150,16 +153,18 @@ def layer_grid(
 
 
 def plot_section(
-    fig, ax, distances, radii, grid, label=None, show=True, levels=25, cmap="turbo"
+    distances,
+    radii,
+    grid,
+    label=None,
+    show=True,
+    levels=25,
+    cmap="turbo",
+    fig=None,
+    ax=None,
 ):
     """
     Create a plot of a cross-section.
-
-    :param fig: figure handle
-    :type fig: matplotlib.figure.Figure
-
-    :param ax: axis handle
-    :type ax: matplotlib.axes._axes.Axes
 
     :param distances: Distances along cross section, given as the angle
         subtended at the Earth's centre between the starting and
@@ -185,6 +190,12 @@ def plot_section(
 
     :param show: If `True` (default), show the plot
     :type show: bool
+
+    :param fig: figure handle
+    :type fig: matplotlib.figure.Figure
+
+    :param ax: axis handle
+    :type ax: matplotlib.axes._axes.Axes
 
     :returns: figure and axis handles
     """
@@ -230,8 +241,8 @@ def spectral_heterogeneity(
     savepath,
     lyrmin,
     lyrmax,
-    fig,
-    ax,
+    fig=None,
+    ax=None,
     **subplots_kwargs,
 ):
     """

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -36,7 +36,7 @@ def layer_grid(
     cmap=None,
     vmin=None,
     vmax=None,
-    **subplots_kwargs
+    **subplots_kwargs,
 ):
     """
     Take a set of arbitrary points in longitude and latitude, each
@@ -68,8 +68,8 @@ def layer_grid(
     if not _CARTOPY_INSTALLED:
         sys.stderr.write("layer_grid require cartopy to be installed")
         raise _CARTOPY_NOT_INSTALLED_EXCEPTION
-    
-    if fig==None or ax==None:
+
+    if fig == None or ax == None:
         fig, ax = plt.subplots(
             subplot_kw={"projection": ccrs.EqualEarth(), **subplots_kwargs}
         )
@@ -116,15 +116,17 @@ def layer_grid(
     grid = np.flip(grid, axis=0)
 
     transform = ccrs.PlateCarree()
-    #ax.set_extent(extent,crs=transform)
-   
+    # ax.set_extent(extent,crs=transform)
+
     if cmap is None:
-        cmap = 'viridis'
+        cmap = "viridis"
 
-    vmin=np.min(grid) if vmin==None else vmin
-    vmax=np.max(grid) if vmax==None else vmax  
+    vmin = np.min(grid) if vmin == None else vmin
+    vmax = np.max(grid) if vmax == None else vmax
 
-    contours = ax.imshow(grid, transform=transform, extent=extent, cmap=cmap, vmin=vmin, vmax=vmax)
+    contours = ax.imshow(
+        grid, transform=transform, extent=extent, cmap=cmap, vmin=vmin, vmax=vmax
+    )
     ax.set_title(f"Radius {int(radius)} km")
     ax.set_xlabel(f"{label}", fontsize=12)
 
@@ -148,15 +150,7 @@ def layer_grid(
 
 
 def plot_section(
-    fig, 
-    ax, 
-    distances, 
-    radii, 
-    grid, 
-    label=None, 
-    show=True, 
-    levels=25, 
-    cmap="turbo"
+    fig, ax, distances, radii, grid, label=None, show=True, levels=25, cmap="turbo"
 ):
     """
     Create a plot of a cross-section.
@@ -195,7 +189,7 @@ def plot_section(
     :returns: figure and axis handles
     """
 
-    if fig==None or ax==None:
+    if fig == None or ax == None:
         fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
 
     distances_radians = np.radians(distances)
@@ -261,7 +255,7 @@ def spectral_heterogeneity(
     logged = np.log(indat[lyrmin:lyrmax, lmin : lmax + 1])
     deps = depths[lyrmin:lyrmax]
 
-    if fig==None or ax==None:
+    if fig == None or ax == None:
         fig, ax = plt.subplots(figsize=(8, 6), **subplots_kwargs)
 
     plotmin = np.min(logged)

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1301,7 +1301,15 @@ class TerraModel:
             label = title
 
         fig, ax, cbar = plot.layer_grid(
-            fig, ax, lon, lat, rad, hp_remake, delta=delta, extent=extent, label=label
+            lon,
+            lat,
+            rad,
+            hp_remake,
+            delta=delta,
+            extent=extent,
+            label=label,
+            fig=fig,
+            ax=ax,
         )
 
         if depth:
@@ -1393,8 +1401,8 @@ class TerraModel:
             savepath,
             lyrmin,
             lyrmax,
-            fig,
-            ax,
+            fig=fig,
+            ax=ax,
             **subplots_kwargs,
         )
 
@@ -1481,8 +1489,6 @@ class TerraModel:
             cmap = _FIELD_COLOUR_SCALE[field]
 
         fig, ax, cbar = plot.layer_grid(
-            fig,
-            ax,
             lon,
             lat,
             layer_radius,
@@ -1495,6 +1501,8 @@ class TerraModel:
             cmap=cmap,
             vmin=vmin,
             vmax=vmax,
+            fig=fig,
+            ax=ax,
         )
 
         if depth:
@@ -1640,8 +1648,6 @@ class TerraModel:
             cmap = _FIELD_COLOUR_SCALE[field]
 
         fig, ax, cbar = plot.plot_section(
-            fig,
-            ax,
             distances,
             radii,
             grid,
@@ -1649,6 +1655,8 @@ class TerraModel:
             levels=levels,
             show=show,
             label=label,
+            fig=fig,
+            ax=ax,
         )
 
         return fig, ax, cbar
@@ -1939,9 +1947,7 @@ class TerraModel:
             label = "n-layers plume detected"
             radius = 0.0
 
-            fig, ax = plot.layer_grid(
-                fig,
-                ax,
+            fig, ax, cbar = plot.layer_grid(
                 lon,
                 lat,
                 radius,
@@ -1951,6 +1957,8 @@ class TerraModel:
                 label=label,
                 method=method,
                 coastlines=coastlines,
+                fig=fig,
+                ax=ax,
             )
 
             mindep = np.min(self.plm_depth_range)
@@ -1966,7 +1974,7 @@ class TerraModel:
             if show:
                 fig.show()
 
-            return fig, ax
+            return fig, ax, cbar
 
         def plot_plumes_3d(
             self,

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1404,9 +1404,14 @@ class TerraModel:
         index=None,
         depth=False,
         delta=None,
+        fig=None,
+        ax=None,
         extent=(-180, 180, -90, 90),
         method="nearest",
         coastlines=True,
+        cmap=None,
+        vmin=None,
+        vmax=None,
         show=True,
     ):
         """
@@ -1449,7 +1454,12 @@ class TerraModel:
         values = self.get_field(field)[layer_index]
         label = _SCALAR_FIELDS[field]
 
-        fig, ax = plot.layer_grid(
+        if cmap is None:
+            cmap = _FIELD_COLOUR_SCALE[field]
+
+        fig, ax, cbar = plot.layer_grid(
+            fig,
+            ax,
             lon,
             lat,
             layer_radius,
@@ -1459,6 +1469,9 @@ class TerraModel:
             label=label,
             method=method,
             coastlines=coastlines,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax
         )
 
         if depth:
@@ -1467,7 +1480,7 @@ class TerraModel:
         if show:
             fig.show()
 
-        return fig, ax
+        return fig, ax, cbar
 
     def plot_section(
         self,
@@ -1476,6 +1489,8 @@ class TerraModel:
         lat,
         azimuth,
         distance,
+        fig=None,
+        ax=None,
         minradius=None,
         maxradius=None,
         delta_distance=1,
@@ -1595,11 +1610,11 @@ class TerraModel:
         if cmap is None:
             cmap = _FIELD_COLOUR_SCALE[field]
 
-        fig, ax = plot.plot_section(
-            distances, radii, grid, cmap=cmap, levels=levels, show=show, label=label
+        fig, ax, cbar = plot.plot_section(
+            fig, ax, distances, radii, grid, cmap=cmap, levels=levels, show=show, label=label
         )
 
-        return fig, ax
+        return fig, ax, cbar
 
     def add_adiabat(self):
         """
@@ -1854,6 +1869,8 @@ class TerraModel:
             extent=(-180, 180, -90, 90),
             method="nearest",
             coastlines=True,
+            fig=None,
+            ax=None,
             show=True,
         ):
             """
@@ -1886,6 +1903,8 @@ class TerraModel:
             radius = 0.0
 
             fig, ax = plot.layer_grid(
+                fig,
+                ax,
                 lon,
                 lat,
                 radius,

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1213,6 +1213,8 @@ class TerraModel:
         index=None,
         radius=None,
         depth=False,
+        fig=None,
+        ax=None,
         nside=2**6,
         title=None,
         delta=None,
@@ -1231,6 +1233,15 @@ class TerraModel:
 
         :param radius: radius to plot (nearest model radius is shown)
         :type radius: float
+        
+        :param depth: interpret radius as depth 
+        :type depth: bool
+
+        :param fig: figure handle
+        :type fig: matplotlib.figure.Figure
+
+        :param ax: axis handle
+        :type ax: matplotlib.axes._axes.Axes
 
         :param nside: healpy param, number of sides for healpix grid, power
             of 2 less than 2**30 (default 2**6)
@@ -1257,7 +1268,7 @@ class TerraModel:
         :param **subplots_kwargs: Extra keyword arguments passed to
             `matplotlib.pyplot.subplots`
 
-        :returns: figure and axis handles
+        :returns: figure, axis and colourbar handles
         """
 
         if radius is None and index is None:
@@ -1289,8 +1300,8 @@ class TerraModel:
         else:
             label = title
 
-        fig, ax = plot.layer_grid(
-            lon, lat, rad, hp_remake, delta=delta, extent=extent, label=label
+        fig, ax, cbar = plot.layer_grid(
+            fig, ax, lon, lat, rad, hp_remake, delta=delta, extent=extent, label=label
         )
 
         if depth:
@@ -1301,7 +1312,7 @@ class TerraModel:
         if show:
             fig.show()
 
-        return fig, ax
+        return fig, ax, cbar
 
     def plot_spectral_heterogeneity(
         self,
@@ -1309,6 +1320,8 @@ class TerraModel:
         title=None,
         saveplot=False,
         savepath=None,
+        fig=None,
+        ax=None,
         lmin=1,
         lmax=None,
         lyrmin=1,
@@ -1331,6 +1344,12 @@ class TerraModel:
         :param savepath: path under which to save plot to
         :type savepath: str
 
+        :param fig: figure handle
+        :type fig: matplotlib.figure.Figure
+
+        :param ax: axis handle
+        :type ax: matplotlib.axes._axes.Axes
+
         :param lmin: minimum spherical harmonic degree to plot (default=1)
         :type lmin: int
 
@@ -1349,7 +1368,7 @@ class TerraModel:
         :param **subplots_kwargs: Extra keyword arguments passed to
             `matplotlib.pyplot.subplots`
 
-        :returns: figure and axis handles
+        :returns: figure, axis, colourbar handles
         """
         dat = self.get_spherical_harmonics(field)
         nr = len(dat)
@@ -1364,7 +1383,7 @@ class TerraModel:
         radii = self.get_radii()
         depths = self.get_radii()[-1] - radii
 
-        fig, ax = plot.spectral_heterogeneity(
+        fig, ax, cbar = plot.spectral_heterogeneity(
             powers,
             title,
             depths,
@@ -1374,13 +1393,15 @@ class TerraModel:
             savepath,
             lyrmin,
             lyrmax,
+            fig,
+            ax,
             **subplots_kwargs,
         )
 
         if show:
             fig.show()
 
-        return fig, ax
+        return fig, ax, cbar
 
     def calc_bulk_composition(self):
         """
@@ -1425,6 +1446,8 @@ class TerraModel:
             field exactly at a layer index
         :param depth: If True, interpret the radius as a depth instead
         :param delta: Grid spacing of plot in degrees
+        :param fig: figure handle
+        :param ax: axis handle
         :param extent: Tuple giving the longitude and latitude extent of
             plot, in the form (min_lon, max_lon, min_lat, max_lat), all
             in degrees
@@ -1521,6 +1544,12 @@ class TerraModel:
             end points of the section, in degrees.
         :type distance: float
 
+        :param fig: figure handle
+        :type fig: matplotlib.figure.Figure
+
+        :param ax: axis handle
+        :type ax: matplotlib.axes._axes.Axes
+
         :param minradius: Minimum radius to plot in km.  If this is smaller
             than the minimum radius in the model, the model's value is used.
         :type minradius: float
@@ -1554,7 +1583,7 @@ class TerraModel:
         :param show: If `True` (default), show the plot
         :type show: bool
 
-        :returns: figure and axis handles
+        :returns: figure,axis and colourbar handles
         """
         if not _is_scalar_field(field):
             raise ValueError(f"Cannot plot non-scalr field '{field}'")

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1233,8 +1233,8 @@ class TerraModel:
 
         :param radius: radius to plot (nearest model radius is shown)
         :type radius: float
-        
-        :param depth: interpret radius as depth 
+
+        :param depth: interpret radius as depth
         :type depth: bool
 
         :param fig: figure handle
@@ -1494,7 +1494,7 @@ class TerraModel:
             coastlines=coastlines,
             cmap=cmap,
             vmin=vmin,
-            vmax=vmax
+            vmax=vmax,
         )
 
         if depth:
@@ -1640,7 +1640,15 @@ class TerraModel:
             cmap = _FIELD_COLOUR_SCALE[field]
 
         fig, ax, cbar = plot.plot_section(
-            fig, ax, distances, radii, grid, cmap=cmap, levels=levels, show=show, label=label
+            fig,
+            ax,
+            distances,
+            radii,
+            grid,
+            cmap=cmap,
+            levels=levels,
+            show=show,
+            label=label,
         )
 
         return fig, ax, cbar

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -71,7 +71,7 @@ class TestLayerGrid(unittest.TestCase):
         radius = 4000
         values = np.random.rand(n)
 
-        fig, ax = plot.layer_grid(lon, lat, radius, values)
+        fig, ax, cbar = plot.layer_grid(lon, lat, radius, values)
 
         self.assertIsInstance(fig, Figure)
         self.assertIsInstance(ax, GeoAxesSubplot)

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -633,7 +633,7 @@ class TestModelHealpy(unittest.TestCase):
     def test_plot_spectral_heterogeneity(self):
         model = dummy_model(with_fields=True)
         model.calc_spherical_harmonics("t")
-        fig, ax = model.plot_spectral_heterogeneity("t", lyrmin=0, lyrmax=-1)
+        fig, ax, cbar = model.plot_spectral_heterogeneity("t", lyrmin=0, lyrmax=-1)
         self.assertIsInstance(fig, Figure)
         self.assertEqual(ax.get_xlabel(), "L")
         self.assertEqual(ax.get_ylabel(), "Depth (km)")
@@ -674,7 +674,7 @@ class TestBoundingIndices(unittest.TestCase):
 class TestPlotSection(unittest.TestCase):
     def test_plot_section(self):
         model = dummy_model(with_fields=True)
-        fig, ax = model.plot_section("t", 10, 20, 30, 120, show=False)
+        fig, ax, cbar = model.plot_section("t", 10, 20, 30, 120, show=False)
         self.assertIsInstance(fig, Figure)
         self.assertIsInstance(ax, PolarAxes)
 
@@ -682,7 +682,7 @@ class TestPlotSection(unittest.TestCase):
         model = dummy_model(with_fields=True)
         radii = model.get_radii()
         radius_diff = radii[-1] - radii[0]
-        fig, ax = model.plot_section(
+        fig, ax, cbar = model.plot_section(
             "t", 10, 20, 30, 120, delta_radius=radius_diff + 1, show=False
         )
         self.assertIsInstance(fig, Figure)
@@ -705,19 +705,19 @@ if _CARTOPY_INSTALLED:
 
         def test_plot_layer_radius(self):
             model = dummy_model(with_fields=True)
-            fig, ax = model.plot_layer("t", 4000, show=False)
+            fig, ax, cbar = model.plot_layer("t", 4000, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
         def test_plot_layer_depth(self):
             model = dummy_model(with_fields=True)
-            fig, ax = model.plot_layer("t", 100, depth=True, show=False)
+            fig, ax, cbar = model.plot_layer("t", 100, depth=True, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
         def test_plot_layer_index(self):
             model = dummy_model(with_fields=True)
-            fig, ax = model.plot_layer("t", index=2, depth=True, show=False)
+            fig, ax, cbar = model.plot_layer("t", index=2, depth=True, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
@@ -725,7 +725,7 @@ if _CARTOPY_INSTALLED:
         def test_plot_hp_map(self):
             model = dummy_model(with_fields=True)
             model.calc_spherical_harmonics("t")
-            fig, ax = model.plot_hp_map("t", index=1)
+            fig, ax, cbar = model.plot_hp_map("t", index=1)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 


### PR DESCRIPTION
In this PR, which relates to #115 , I have added the ability to pass in figure and axis handles into some of the plotting routines, namely `plot_layer`, `plot_section`, `plot_spectral_heterogeneity` and `plot_hp_map`. 
I have also made these functions return the handle to the colorbar to allow greater flexibility to users when producing figures. As such calls to these plotting functions in tests and examples have been updated in this PR.

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
