### PR TITLE
return cbar from plotting functions only if passed `return_cbar=True`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,4 +19,8 @@ _First release._
   ## [1.0.2] - 2024-03-12
 
   - Patch to allow adding of new fields with arbitrary name to the TerraModel.
- 
+
+  ## [1.1.0]  - 2024-06-06
+
+  - Allowing passing fig and ax handles to plotting functions.
+  - Return colorbar from plotting functions if requested with `return_cbar=True`

--- a/examples/example_cross_section.py
+++ b/examples/example_cross_section.py
@@ -58,7 +58,7 @@ interpolation, and only plot the field near the surface:
 """
 
 # %%
-fig, ax, cbar = model.plot_section(
+fig, ax = model.plot_section(
     "t",
     lon=0,
     lat=-30,

--- a/examples/example_plot_map.py
+++ b/examples/example_plot_map.py
@@ -42,7 +42,7 @@ Plotting depth slices in terratools is very easy. First we show a basic plot for
 # %%
 
 # Note we set depth=True to define the depth as 2800
-fig, ax, cbar = model.plot_layer(field="t", radius=2800, depth=True, show=False)
+fig, ax = model.plot_layer(field="t", radius=2800, depth=True, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature field at 2800 km depth")
 plt.show()
@@ -58,7 +58,7 @@ We can do the same thing with other scalar fields such as the bulk composition.
 model.calc_bulk_composition()
 
 # Note bulk composition is in the "c" field.
-fig, ax, cbar = model.plot_layer(field="c", radius=2800, depth=True, show=False)
+fig, ax = model.plot_layer(field="c", radius=2800, depth=True, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Bulk composition at 2800 km depth")
 plt.show()
@@ -71,7 +71,7 @@ Rather than defining a radius, we can give an index for the layer we want to plo
 
 # %%
 
-fig, ax, cbar = model.plot_layer(field="t", index=10, show=False)
+fig, ax = model.plot_layer(field="t", index=10, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature at the index 10.")
 plt.show()
@@ -84,9 +84,7 @@ We can also change the sampling resolution by varying the delta argument.
 # %%
 
 # plot with intervals of 5 degrees on longitude and latitude.
-fig, ax, cbar = model.plot_layer(
-    field="t", radius=2800, depth=True, delta=5, show=False
-)
+fig, ax = model.plot_layer(field="t", radius=2800, depth=True, delta=5, show=False)
 fig.set_size_inches(8, 6)
 ax.set_title("Temperature on a 5$^{\circ}$ grid at 2800 km depth.")
 plt.show()
@@ -107,7 +105,7 @@ max_la = 30
 
 region = (min_lo, max_lo, min_la, max_la)
 
-fig, ax, cbar = model.plot_layer(
+fig, ax = model.plot_layer(
     field="t", radius=2800, depth=True, show=False, extent=region
 )
 fig.set_size_inches(8, 6)

--- a/examples/example_spherical_harmonics.py
+++ b/examples/example_spherical_harmonics.py
@@ -72,7 +72,7 @@ We can plot the power spectra of the for fields as a function of depth using:
 """
 # %%
 
-fig, ax, cmap = model.plot_spectral_heterogeneity("c", lyrmin=0, lyrmax=-1, show=False)
+fig, ax = model.plot_spectral_heterogeneity("c", lyrmin=0, lyrmax=-1, show=False)
 plt.show()
 
 # %% [markdown]

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -271,6 +271,7 @@ def spectral_heterogeneity(
     :param lyrmax: maximum layer to plot
     :param fig: figure handle
     :param ax: axis handle
+    :param return_cbar: flag to return colorbar
     :param **subplots_kwargs: Extra keyword arguments passed to
             `matplotlib.pyplot.subplots`
     :returns: tuple of figure, axis and cbar handles, respectively

--- a/terratools/plot.py
+++ b/terratools/plot.py
@@ -36,6 +36,7 @@ def layer_grid(
     vmax=None,
     fig=None,
     ax=None,
+    return_cbar=False,
     **subplots_kwargs,
 ):
     """
@@ -64,6 +65,7 @@ def layer_grid(
     :param vamx: maximum value to show on plot
     :param fig: figure handle
     :param ax: axis handle
+    :param return_cbar: return the colourbar
     :param **subplots_kwargs: Extra keyword arguments passed to
         `matplotlib.pyplot.subplots`
     :returns: tuple of figure and axis handles, respectively
@@ -149,7 +151,10 @@ def layer_grid(
     if coastlines:
         ax.coastlines()
 
-    return fig, ax, cbar
+    if return_cbar:
+        return fig, ax, cbar
+    else:
+        return fig, ax
 
 
 def plot_section(
@@ -162,6 +167,7 @@ def plot_section(
     cmap="turbo",
     fig=None,
     ax=None,
+    return_cbar=False,
 ):
     """
     Create a plot of a cross-section.
@@ -197,6 +203,9 @@ def plot_section(
     :param ax: axis handle
     :type ax: matplotlib.axes._axes.Axes
 
+    :param return_cbar: return the colourbar
+    :type return_cbar: bool
+
     :returns: figure and axis handles
     """
 
@@ -228,7 +237,10 @@ def plot_section(
     if show:
         plt.show()
 
-    return fig, ax, cbar
+    if return_cbar:
+        return fig, ax, cbar
+    else:
+        return fig, ax
 
 
 def spectral_heterogeneity(
@@ -243,6 +255,7 @@ def spectral_heterogeneity(
     lyrmax,
     fig=None,
     ax=None,
+    return_cbar=False,
     **subplots_kwargs,
 ):
     """
@@ -293,7 +306,10 @@ def spectral_heterogeneity(
             f"{savepath}/powers_{title}.pdf", format="pdf", dpi=200, bbox_inches="tight"
         )
 
-    return fig, ax, cbar
+    if return_cbar:
+        return fig, ax, cbar
+    else:
+        return fig, ax
 
 
 def plumes_3d(

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1215,6 +1215,7 @@ class TerraModel:
         depth=False,
         fig=None,
         ax=None,
+        return_cbar=False,
         nside=2**6,
         title=None,
         delta=None,
@@ -1300,7 +1301,7 @@ class TerraModel:
         else:
             label = title
 
-        fig, ax, cbar = plot.layer_grid(
+        returned = plot.layer_grid(
             lon,
             lat,
             rad,
@@ -1310,7 +1311,12 @@ class TerraModel:
             label=label,
             fig=fig,
             ax=ax,
+            return_cbar=return_cbar,
         )
+
+        fig = returned[0]
+        ax = returned[1]
+        cbar = returned[2] if return_cbar else None
 
         if depth:
             ax.set_title(f"Depth = {int(layer_radius)} km")
@@ -1320,7 +1326,10 @@ class TerraModel:
         if show:
             fig.show()
 
-        return fig, ax, cbar
+        if return_cbar:
+            return fig, ax, cbar
+        else:
+            return fig, ax
 
     def plot_spectral_heterogeneity(
         self,
@@ -1330,6 +1339,7 @@ class TerraModel:
         savepath=None,
         fig=None,
         ax=None,
+        return_cbar=False,
         lmin=1,
         lmax=None,
         lyrmin=1,
@@ -1391,7 +1401,7 @@ class TerraModel:
         radii = self.get_radii()
         depths = self.get_radii()[-1] - radii
 
-        fig, ax, cbar = plot.spectral_heterogeneity(
+        returned = plot.spectral_heterogeneity(
             powers,
             title,
             depths,
@@ -1403,13 +1413,21 @@ class TerraModel:
             lyrmax,
             fig=fig,
             ax=ax,
+            return_cbar=return_cbar,
             **subplots_kwargs,
         )
+
+        fig = returned[0]
+        ax = returned[1]
+        cbar = returned[2] if return_cbar else None
 
         if show:
             fig.show()
 
-        return fig, ax, cbar
+        if return_cbar:
+            return fig, ax, cbar
+        else:
+            return fig, ax
 
     def calc_bulk_composition(self):
         """
@@ -1435,6 +1453,7 @@ class TerraModel:
         delta=None,
         fig=None,
         ax=None,
+        return_cbar=False,
         extent=(-180, 180, -90, 90),
         method="nearest",
         coastlines=True,
@@ -1488,7 +1507,7 @@ class TerraModel:
         if cmap is None:
             cmap = _FIELD_COLOUR_SCALE[field]
 
-        fig, ax, cbar = plot.layer_grid(
+        returned = plot.layer_grid(
             lon,
             lat,
             layer_radius,
@@ -1503,7 +1522,12 @@ class TerraModel:
             vmax=vmax,
             fig=fig,
             ax=ax,
+            return_cbar=return_cbar,
         )
+
+        fig = returned[0]
+        ax = returned[1]
+        cbar = returned[2] if return_cbar else None
 
         if depth:
             ax.set_title(f"Depth {int(layer_radius)} km")
@@ -1511,7 +1535,10 @@ class TerraModel:
         if show:
             fig.show()
 
-        return fig, ax, cbar
+        if return_cbar:
+            return fig, ax, cbar
+        else:
+            return fig, ax
 
     def plot_section(
         self,
@@ -1522,6 +1549,7 @@ class TerraModel:
         distance,
         fig=None,
         ax=None,
+        return_cbar=False,
         minradius=None,
         maxradius=None,
         delta_distance=1,
@@ -1647,7 +1675,7 @@ class TerraModel:
         if cmap is None:
             cmap = _FIELD_COLOUR_SCALE[field]
 
-        fig, ax, cbar = plot.plot_section(
+        returned = plot.plot_section(
             distances,
             radii,
             grid,
@@ -1657,9 +1685,17 @@ class TerraModel:
             label=label,
             fig=fig,
             ax=ax,
+            return_cbar=return_cbar,
         )
 
-        return fig, ax, cbar
+        fig = returned[0]
+        ax = returned[1]
+        cbar = returned[2] if return_cbar else None
+
+        if return_cbar:
+            return fig, ax, cbar
+        else:
+            return fig, ax
 
     def add_adiabat(self):
         """
@@ -1916,6 +1952,7 @@ class TerraModel:
             coastlines=True,
             fig=None,
             ax=None,
+            return_cbar=False,
             show=True,
         ):
             """
@@ -1947,7 +1984,7 @@ class TerraModel:
             label = "n-layers plume detected"
             radius = 0.0
 
-            fig, ax, cbar = plot.layer_grid(
+            returned = plot.layer_grid(
                 lon,
                 lat,
                 radius,
@@ -1959,7 +1996,12 @@ class TerraModel:
                 coastlines=coastlines,
                 fig=fig,
                 ax=ax,
+                return_cbar=return_cbar,
             )
+
+            fig = returned[0]
+            ax = returned[1]
+            cbar = returned[2] if return_cbar else None
 
             mindep = np.min(self.plm_depth_range)
             maxdep = np.max(self.plm_depth_range)
@@ -1974,7 +2016,10 @@ class TerraModel:
             if show:
                 fig.show()
 
-            return fig, ax, cbar
+            if return_cbar:
+                return fig, ax, cbar
+            else:
+                return fig, ax
 
         def plot_plumes_3d(
             self,

--- a/terratools/terra_model.py
+++ b/terratools/terra_model.py
@@ -1244,6 +1244,9 @@ class TerraModel:
         :param ax: axis handle
         :type ax: matplotlib.axes._axes.Axes
 
+        :param return_cbar: flag to return colorbar
+        :type ax: bool
+
         :param nside: healpy param, number of sides for healpix grid, power
             of 2 less than 2**30 (default 2**6)
         :type nside: int (power of 2)
@@ -1368,6 +1371,9 @@ class TerraModel:
         :param ax: axis handle
         :type ax: matplotlib.axes._axes.Axes
 
+        :param return_cbar: flag to return colorbar
+        :type return_cbar: bool
+
         :param lmin: minimum spherical harmonic degree to plot (default=1)
         :type lmin: int
 
@@ -1475,6 +1481,7 @@ class TerraModel:
         :param delta: Grid spacing of plot in degrees
         :param fig: figure handle
         :param ax: axis handle
+        :param return_cbar: flag to return colorbar
         :param extent: Tuple giving the longitude and latitude extent of
             plot, in the form (min_lon, max_lon, min_lat, max_lat), all
             in degrees
@@ -1585,6 +1592,9 @@ class TerraModel:
 
         :param ax: axis handle
         :type ax: matplotlib.axes._axes.Axes
+
+        :param return_cbar: flag to return colorbar
+        :type return_cbar: bool
 
         :param minradius: Minimum radius to plot in km.  If this is smaller
             than the minimum radius in the model, the model's value is used.
@@ -1971,6 +1981,9 @@ class TerraModel:
                 This may lead to a segfault on machines where cartopy is not
                 installed in the recommended way.  In this case, pass ``False``
                 to avoid this.
+            :param fig: figure handle
+            :param ax: axis handle
+            :param return_cbar: flag to return colorbar
             :param show: If ``True`` (the default), show the plot
             :returns: figure and axis handles
             """

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -71,7 +71,7 @@ class TestLayerGrid(unittest.TestCase):
         radius = 4000
         values = np.random.rand(n)
 
-        fig, ax, cbar = plot.layer_grid(lon, lat, radius, values)
+        fig, ax = plot.layer_grid(lon, lat, radius, values)
 
         self.assertIsInstance(fig, Figure)
         self.assertIsInstance(ax, GeoAxesSubplot)

--- a/tests/test_terra_model.py
+++ b/tests/test_terra_model.py
@@ -633,7 +633,7 @@ class TestModelHealpy(unittest.TestCase):
     def test_plot_spectral_heterogeneity(self):
         model = dummy_model(with_fields=True)
         model.calc_spherical_harmonics("t")
-        fig, ax, cbar = model.plot_spectral_heterogeneity("t", lyrmin=0, lyrmax=-1)
+        fig, ax = model.plot_spectral_heterogeneity("t", lyrmin=0, lyrmax=-1)
         self.assertIsInstance(fig, Figure)
         self.assertEqual(ax.get_xlabel(), "L")
         self.assertEqual(ax.get_ylabel(), "Depth (km)")
@@ -674,7 +674,7 @@ class TestBoundingIndices(unittest.TestCase):
 class TestPlotSection(unittest.TestCase):
     def test_plot_section(self):
         model = dummy_model(with_fields=True)
-        fig, ax, cbar = model.plot_section("t", 10, 20, 30, 120, show=False)
+        fig, ax = model.plot_section("t", 10, 20, 30, 120, show=False)
         self.assertIsInstance(fig, Figure)
         self.assertIsInstance(ax, PolarAxes)
 
@@ -682,7 +682,7 @@ class TestPlotSection(unittest.TestCase):
         model = dummy_model(with_fields=True)
         radii = model.get_radii()
         radius_diff = radii[-1] - radii[0]
-        fig, ax, cbar = model.plot_section(
+        fig, ax = model.plot_section(
             "t", 10, 20, 30, 120, delta_radius=radius_diff + 1, show=False
         )
         self.assertIsInstance(fig, Figure)
@@ -705,19 +705,19 @@ if _CARTOPY_INSTALLED:
 
         def test_plot_layer_radius(self):
             model = dummy_model(with_fields=True)
-            fig, ax, cbar = model.plot_layer("t", 4000, show=False)
+            fig, ax = model.plot_layer("t", 4000, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
         def test_plot_layer_depth(self):
             model = dummy_model(with_fields=True)
-            fig, ax, cbar = model.plot_layer("t", 100, depth=True, show=False)
+            fig, ax = model.plot_layer("t", 100, depth=True, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
         def test_plot_layer_index(self):
             model = dummy_model(with_fields=True)
-            fig, ax, cbar = model.plot_layer("t", index=2, depth=True, show=False)
+            fig, ax = model.plot_layer("t", index=2, depth=True, show=False)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 
@@ -725,7 +725,7 @@ if _CARTOPY_INSTALLED:
         def test_plot_hp_map(self):
             model = dummy_model(with_fields=True)
             model.calc_spherical_harmonics("t")
-            fig, ax, cbar = model.plot_hp_map("t", index=1)
+            fig, ax = model.plot_hp_map("t", index=1)
             self.assertIsInstance(fig, Figure)
             self.assertIsInstance(ax, GeoAxesSubplot)
 


### PR DESCRIPTION
Addressing comment on #152 to only return `cbar` from plotting functions if requested by passing `return_cbar=True`.
This will prevent the breaking change to allow backwards compatibility. 

### For all pull requests:

* [X] I have run the [`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/changes](../blob/main/doc/changes) directory that will inform other users of my change.
