### PR TITLE
Replace the use of distutils with shutil

### DIFF
--- a/terratools/convert_files.py
+++ b/terratools/convert_files.py
@@ -1,9 +1,9 @@
 import netCDF4 as nc4
 import sys
 import os
+import shutil
 import stat
 import numpy as np
-from distutils.spawn import find_executable
 
 
 class FileTypeError(Exception):
@@ -237,7 +237,7 @@ def _touch(path):
 def _tool_exists(toolname):
     """Check whether `toolname` exists on PATH."""
 
-    return find_executable(toolname) is not None
+    return shutil.which(toolname) is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python 3.13 moves distutils into setuptools, so replace the
use of `distutils.span.find_executable` with `shutil.which`
in the example script which uses it.

### For all pull requests:

* [x] I have run the 
[`contrib/utilities/indent`](../blob/main/contrib/utilities/indent) script from the main directory to indent my code.

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
