### PR TITLE
CI: Update the upload-artifact GitHub action version

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper.pdf
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         ./contrib/utilities/indent
         git diff > changes-astyle.diff
     - name: archive indent results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: changes-astyle.diff
         path: changes-astyle.diff


### PR DESCRIPTION
Some CI runs are currently failing because we use a version of
`actions/upload-artifact` which is too old
(https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).
Replace these uses with the latest version to fix the CI runs.

Longer term, updating them automatically may be prudent
(https://github.com/mantle-convection-constrained/terratools/issues/172).
