### PR TITLE
Retry example data downloads

### DIFF
--- a/terratools/example_data.py
+++ b/terratools/example_data.py
@@ -18,6 +18,7 @@ _EXAMPLE_DATA = pooch.create(
     path=pooch.os_cache("terratools"),
     base_url="doi:10.6084/m9.figshare.24100362.v3",
     registry=None,
+    retry_if_failed=3,
 )
 
 _EXAMPLE_DATA.load_registry_from_doi()


### PR DESCRIPTION
The example data 'distributed' with terratools is actually stored
on Figshare and downloaded (and cached) on demand.  This can cause
problems on CI because multiple runners all try and download the
same file many times simultaneously, and Figure reasonably starts
to reject the requests.  As a workaround, by default retry the
download a few times before giving up.

May address the following issue:
https://github.com/mantle-convection-constrained/terratools/issues/185
