### PR TITLE
Update PyPi via github action

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -11,7 +11,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Build draft PDF

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -21,7 +21,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: paper.pdf
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,4 +1,9 @@
-on: push
+on: 
+  push:
+    paths: 
+      - 'paper/**'
+
+permissions: {}
 
 jobs:
   paper:
@@ -7,8 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
+        uses: openjournals/openjournals-draft-action@85a18372e48f551d8af9ddb7a747de685fbbb01c #v1.0
         with:
           journal: joss
           # This should be the path to the paper within your repo.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         python-versions: ['3.10']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
@@ -45,7 +45,7 @@ jobs:
         python-versions: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
@@ -91,7 +91,7 @@ jobs:
         python-versions: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-versions }}
     - name: make indent
@@ -28,7 +28,7 @@ jobs:
         ./contrib/utilities/indent
         git diff > changes-astyle.diff
     - name: archive indent results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: changes-astyle.diff
         path: changes-astyle.diff
@@ -49,7 +49,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-versions }}
     - name: setup
@@ -64,7 +64,7 @@ jobs:
         python -m pip install pooch
         echo CACHE=$(python -c 'import pooch; print(pooch.os_cache("terratools"))') >> $GITHUB_OUTPUT
     - name: Figshare restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       id: restore-from-figshare
       with:
         path: ${{ steps.setup.outputs.CACHE }}
@@ -76,7 +76,7 @@ jobs:
       run: |
         PYTHON=python ./test.sh
     - name: Figshare cache data
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       id: cache-figshare
       with:
         path: ${{ steps.setup.outputs.CACHE }}
@@ -95,7 +95,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-versions }}
     - name: setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: test
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 jobs:
   indent:
     name: indent
@@ -14,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
       uses: actions/setup-python@v6
       with:
@@ -42,6 +46,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
       uses: actions/setup-python@v6
       with:
@@ -86,6 +92,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-versions }}
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+# Put a version on PyPI when a GitHub release is published
+on:
+ release:
+   types: [published]
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.12"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish distribution
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/terratools 
+    permissions:
+      id-token: write  
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: Zizmor security analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0


### PR DESCRIPTION
Changes to github actions to allow us to update the version on PyPi (i.e. the version that pip will install) when making a release on github. This PR:

* Audits the security of the existing github actions
* Adds an automate scanner for actions
* Creates a new action to build and upload the package to PyPi that runs on the github release trigger

There will be some configuration to do on github and pypi before this works (specifically checking our github repository security settings, creating an environment to run the upload from, and setting up trusted publishing on pypi). 
