### PR TITLE
Docs: Update readthedocs runner OS version

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.9"
   apt_packages:


### PR DESCRIPTION
The current version of Ubuntu used to build the docs on Read the
Docs is 20.04, which is now no longer getting security updates.
Update the runner to use Ubuntu 24.04 instead.
